### PR TITLE
Experimental use of NRO delegated stats

### DIFF
--- a/rpki_as0_bogons/slurm.py
+++ b/rpki_as0_bogons/slurm.py
@@ -36,7 +36,7 @@ def main():
 
     parser.add_argument("-f",
             dest='dest_file',
-            default="/usr/local/etc/bogons.slurm.txt",
+            default="/usr/local/etc/slurm.json",
             help="File to be created with all the SLURM content (default is /usr/local/etc/slurm.json)")
 
     parser.add_argument("--use-delegated-stats",


### PR DESCRIPTION
Creates an AS0 ROA for all prefixes listed in the NRO delegated stats that contains status "available" or "ianapool" or "ietf" or "reserved" - basically it means NOT "assigned".

This feature is EXPERIMENTAL.

