### PR TITLE
Fix Slurm bgpsecFilters attribute name; It caused RPKI validator-3 to fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You can find the software on PyPi, so you can install it easily via pip.
 ## Usage
 
 ```shell
-usage: slurm.py [-h] [-f DEST_FILE] [-N]
+usage: slurm.py [-h] [-f DEST_FILE] [-P] (-N | -C)
 
 A script to generate a SLURM file for all bogons with origin AS0
 
@@ -27,9 +27,11 @@ optional arguments:
   -h, --help    show this help message and exit
   -f DEST_FILE  File to be created with all the SLURM content (default is
                 /usr/local/etc/slurm.json)
+  -P            Include the list of IXP LANs from PeeringDB.
+  -C            Use the Team Cymru's bogons list  
   -N            Use the NRO delegated stats instead of Team Cymru's bogon list
 
-Version 0.2
+Version 0.2.1
 ```
 
 By default the Team Cymru lists is used, but if you want to include any network that's not assigned or allocated at the moment, it's better to use the NRO file.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ You should start routinator with the *-x* switch, providing the path to the file
 You can use curl to supply the file to the validator:
 
 ```shell
-/usr/local/bin/curl -X POST -F "file=slurm.json" localhost:8080/api/slurm/upload
+/usr/local/bin/curl -X POST -F "file=@slurm.json" localhost:8080/api/slurm/upload
 ```
 
 ### Forth

--- a/rpki_as0_bogons/slurm.py
+++ b/rpki_as0_bogons/slurm.py
@@ -86,7 +86,7 @@ def main():
     output['slurmVersion'] = 1
     output["validationOutputFilters"] = {}
     output["validationOutputFilters"]["prefixFilters"] = []
-    output["validationOutputFilters"]["bgpsecFilter"] = []
+    output["validationOutputFilters"]["bgpsecFilters"] = []
     output["locallyAddedAssertions"] = {}
     output["locallyAddedAssertions"]["prefixAssertions"] = []
     output["locallyAddedAssertions"]["bgpsecAssertions"] = []


### PR DESCRIPTION
RPKI Validator 3 was failing to parse the slurm file because of a missing 's' on bgpsecFilters attribute.
It would fail with a NPE. 